### PR TITLE
feat: use graph name when append logseq url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logseq-todoist-plugin",
-  "version": "4.1.9",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "logseq-todoist-plugin",
-      "version": "4.1.9",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@logseq/libs": "^0.0.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import "@logseq/libs";
 import { getAllLabels, getAllProjects, removePrefix } from "./helpersTodoist";
 import axios from "axios";
 
-export default function App(props: any) {
+export default function App(props: {content: string, uuid:string, graphName: string}) {
   const [projects, setProjects] = useState([]) as any[];
   const [labels, setLabels] = useState([]) as any[];
   const [formData, setFormData] = useState({
@@ -52,7 +52,7 @@ export default function App(props: any) {
     if (logseq.settings!.appendLogseqUri) {
       data["content"] = `[${removePrefix(
         props.content
-      )}](logseq://graph/logseq?block-id=${props.uuid})`;
+      )}](logseq://graph/${props.graphName}?block-id=${props.uuid})`;
     } else {
       data["content"] = removePrefix(props.content);
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,12 +28,13 @@ const main = async () => {
       appendTodoistUrl,
     } = logseq.settings!;
 
+    const currGraphName = (await logseq.App.getCurrentGraph())?.name ?? "logseq"
     const currBlk = (await logseq.Editor.getBlock(e.uuid)) as BlockEntity;
 
     await new Promise((r) => setTimeout(r, 2000));
 
     if (!sendDefaultProject && !sendDefaultLabel && !sendDefaultDeadline) {
-      await sendTask(currBlk.content, currBlk.uuid);
+      await sendTask(currBlk.content, currBlk.uuid, currGraphName);
     } else {
       let data: {
         content: string;
@@ -44,7 +45,7 @@ const main = async () => {
         content: appendLogseqUri
           ? `[${removePrefix(
               currBlk.content
-            )}](logseq://graph/logseq?block-id=${currBlk.uuid})`
+            )}](logseq://graph/${currGraphName}?block-id=${currBlk.uuid})`
           : removePrefix(currBlk.content),
       };
       if (sendDefaultProject && sendDefaultProject !== "---")

--- a/src/sendTask.tsx
+++ b/src/sendTask.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
-export async function sendTask(content: string, uuid: string) {
+export async function sendTask(content: string, uuid: string, graphName: string) {
   ReactDOM.render(
     <React.StrictMode>
-      <App content={content} uuid={uuid} />
+      <App content={content} uuid={uuid} graphName={graphName}/>
     </React.StrictMode>,
     document.getElementById("app")
   );


### PR DESCRIPTION
## Why

When `appendLogseqUri` is enabled, todoist-plugin always append logseq uri as the graph name was "logseq" (as in `logseq://graph/logseq?block-id=xxx`). 

This PR queries current graph name and use it in the deeplink uri for better navigation experience.

## Changes

1. Get current graph name with logseq plugin api `logseq.App.getCurrentGraph()`
2. Pass the graph name to sendTask function.
3. Use graph name in uri.