### PR TITLE
fix: link non-task block to todoist

### DIFF
--- a/src/helpersTodoist.ts
+++ b/src/helpersTodoist.ts
@@ -134,11 +134,20 @@ export function removePrefix(content: string) {
 export function removePrefixWhenAddingTodoistUrl(content: string) {
   const prefixes = ["TODO", "DOING", "NOW", "LATER", "WAITING"];
   let newContent: string = content;
+  let isTaskBlk = false;
+
   for (let p of prefixes) {
     if (newContent.startsWith(p)) {
+      isTaskBlk = true;
       newContent = `${p} [${removePrefix(content).trim()}]`;
+      break;
     }
   }
+
+  if (!isTaskBlk) {
+    newContent = `[${newContent}]`
+  }
+
   return newContent;
 }
 


### PR DESCRIPTION
## Why

Backlinks of non-task blocks are not working properly.

## Changes

Make sure non-task blocks are also getting markdown link syntax`[]`.

Related issue: https://github.com/hkgnp/logseq-todoist-plugin/issues/24#issuecomment-1135501627