### PR TITLE
Feature proposal: Options to control where to attach the link between Todoist and Logseq

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ export default function App(props: {content: string, uuid:string, graphName: str
       newBlockContent = `[${props.content}](${sendResponse.data.url})`
     }
 
-    if (logseq.settings!.appendTodoistUrl === "Link content") {
+    if (logseq.settings!.appendTodoistUrl === "Append link") {
       newBlockContent = `${props.content} [(todoist)](${sendResponse.data.url})`
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,12 +66,21 @@ export default function App(props: {content: string, uuid:string, graphName: str
       },
     });
 
-    if (logseq.settings!.appendTodoistUrl) {
-      await logseq.Editor.updateBlock(
-        props.uuid,
-        `[${props.content}](${sendResponse.data.url})`
-      );
+    let newBlockContent = props.content
+
+    if (logseq.settings!.appendTodoistUrl === "Link content") {
+      newBlockContent = `[${props.content}](${sendResponse.data.url})`
     }
+
+    if (logseq.settings!.appendTodoistUrl === "Link content") {
+      newBlockContent = `${props.content} [(todoist)](${sendResponse.data.url})`
+    }
+
+
+    await logseq.Editor.updateBlock(
+      props.uuid,
+      newBlockContent
+    );
 
     logseq.hideMainUI();
     setFormData({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,13 +49,13 @@ export default function App(props: {content: string, uuid:string, graphName: str
       data["label_ids"] = [parseInt(label_ids)];
     if (priority && priority !== "0") data["priority"] = parseInt(priority);
     if (due_string && due_string !== "") data["due_string"] = due_string;
-    if (logseq.settings!.appendLogseqUri) {
-      data["content"] = `[${removePrefix(
-        props.content
-      )}](logseq://graph/${props.graphName}?block-id=${props.uuid})`;
-    } else {
-      data["content"] = removePrefix(props.content);
-    }
+
+    let blockUri = `logseq://graph/${props.graphName}?block-id=${props.uuid}`
+    let taskTitle = (logseq.settings!.appendLogseqUri === "Link title") ? `[${removePrefix(props.content)}](${blockUri})` : removePrefix(props.content)
+    let taskDes = (logseq.settings!.appendLogseqUri === "Link description") ? `[(logseq link)](${blockUri})`: ""
+
+    data["content"] = taskTitle;
+    data['description'] = taskDes;
 
     const sendResponse = await axios({
       method: "post",

--- a/src/callSettings.ts
+++ b/src/callSettings.ts
@@ -14,6 +14,17 @@ export const callSettings = async () => {
   );
   allLabels.unshift(`---`);
 
+  let appendLogseqUriOptions = ["Disable", "Link title", "Link description"]
+  let appendLogseqUriDefault = "Disable"
+
+  // migrate `appendLogseqUriOptions` to new setting
+  if (logseq.settings?.appendLogseqUri !== undefined && typeof logseq.settings?.appendLogseqUri === 'boolean') {
+    if (logseq.settings.appendLogseqUri) {
+      appendLogseqUriDefault = 'Link title';
+    }
+    logseq.updateSettings({ appendLogseqUri: appendLogseqUriDefault });
+  }
+
   const settings: SettingSchemaDesc[] = [
     {
       key: "apiToken",
@@ -88,8 +99,10 @@ export const callSettings = async () => {
       title: "Append Logseq URI to Description",
       description:
         "If enabled, all tasks sent to Todoist will have the Logseq URI added to the task's description.",
-      type: "boolean",
-      default: true,
+      type: "enum",
+      enumPicker: "select",
+      enumChoices: appendLogseqUriOptions,
+      default: appendLogseqUriDefault,
     },
     {
       key: "appendTodoistUrl",

--- a/src/callSettings.ts
+++ b/src/callSettings.ts
@@ -16,7 +16,6 @@ export const callSettings = async () => {
 
   let appendLogseqUriOptions = ["Disable", "Link title", "Link description"]
   let appendLogseqUriDefault = "Disable"
-
   // migrate `appendLogseqUriOptions` to new setting
   if (logseq.settings?.appendLogseqUri !== undefined && typeof logseq.settings?.appendLogseqUri === 'boolean') {
     if (logseq.settings.appendLogseqUri) {
@@ -24,6 +23,18 @@ export const callSettings = async () => {
     }
     logseq.updateSettings({ appendLogseqUri: appendLogseqUriDefault });
   }
+
+  let appendTodoistUriOptions = ["Disable", "Link content", "Append link"]
+  let appendTodoistUriDefault = "Disable"
+  // migrate `appendLogseqUriOptions` to new setting
+  if (logseq.settings?.appendTodoistUrl !== undefined && typeof logseq.settings?.appendLogseqUri === 'boolean') {
+    if (logseq.settings.appendTodoistUrl) {
+      appendLogseqUriDefault = 'Link content';
+    }
+    logseq.updateSettings({ appendTodoistUri: appendTodoistUriDefault });
+  }
+
+
 
   const settings: SettingSchemaDesc[] = [
     {
@@ -109,8 +120,10 @@ export const callSettings = async () => {
       title: "Append Todoist URL to Block",
       description:
         "If enabled, all tasks sent to Todoist will its Todoist url added to the block after sending.",
-      type: "boolean",
-      default: false,
+        type: "enum",
+      enumPicker: "select",
+      enumChoices: appendTodoistUriOptions,
+      default: appendTodoistUriDefault,
     },
   ];
   logseq.useSettingsSchema(settings);

--- a/src/callSettings.ts
+++ b/src/callSettings.ts
@@ -24,14 +24,14 @@ export const callSettings = async () => {
     logseq.updateSettings({ appendLogseqUri: appendLogseqUriDefault });
   }
 
-  let appendTodoistUriOptions = ["Disable", "Link content", "Append link"]
-  let appendTodoistUriDefault = "Disable"
-  // migrate `appendLogseqUriOptions` to new setting
-  if (logseq.settings?.appendTodoistUrl !== undefined && typeof logseq.settings?.appendLogseqUri === 'boolean') {
+  let appendTodoistUrlOptions = ["Disable", "Link content", "Append link"]
+  let appendTodoistUrlDefault = "Disable"
+  // migrate `appendTodoistUrlDefault` to new setting
+  if (logseq.settings?.appendTodoistUrl !== undefined && typeof logseq.settings?.appendTodoistUrl === 'boolean') {
     if (logseq.settings.appendTodoistUrl) {
-      appendLogseqUriDefault = 'Link content';
+      appendTodoistUrlDefault = 'Link content';
     }
-    logseq.updateSettings({ appendTodoistUri: appendTodoistUriDefault });
+    logseq.updateSettings({ appendTodoistUrl: appendTodoistUrlDefault });
   }
 
 
@@ -122,8 +122,8 @@ export const callSettings = async () => {
         "If enabled, all tasks sent to Todoist will its Todoist url added to the block after sending.",
         type: "enum",
       enumPicker: "select",
-      enumChoices: appendTodoistUriOptions,
-      default: appendTodoistUriDefault,
+      enumChoices: appendTodoistUrlOptions,
+      default: appendTodoistUrlDefault,
     },
   ];
   logseq.useSettingsSchema(settings);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,14 +62,21 @@ const main = async () => {
         ];
 
       const sendResponse = await sendTaskFunction(data);
-      if (appendTodoistUrl) {
-        await logseq.Editor.updateBlock(
-          currBlk.uuid,
-          `${removePrefixWhenAddingTodoistUrl(currBlk.content)}(${
-            sendResponse.url
-          })`
-        );
+
+      let newBlockContent = currBlk.content
+
+      if (appendTodoistUrl === "Link content") {
+        newBlockContent = `${removePrefixWhenAddingTodoistUrl(currBlk.content)}(${sendResponse.url})`
       }
+
+      if (appendTodoistUrl === "Append link") {
+        newBlockContent = `${currBlk.content} [(todoist)](${sendResponse.url})`
+      }
+      await logseq.Editor.updateBlock(
+        currBlk.uuid,
+        newBlockContent
+      );
+
       window.setTimeout(async function () {
         await logseq.Editor.exitEditingMode();
         logseq.App.showMsg(`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,18 +36,21 @@ const main = async () => {
     if (!sendDefaultProject && !sendDefaultLabel && !sendDefaultDeadline) {
       await sendTask(currBlk.content, currBlk.uuid, currGraphName);
     } else {
+      let blockUri = `logseq://graph/${currGraphName}?block-id=${currBlk.uuid}`
+      let taskTitle = (appendLogseqUri === "Link title") ? `[${removePrefix(currBlk.content)}](${blockUri})` : removePrefix(currBlk.content)
+      let taskDes = (appendLogseqUri === "Link description") ? `[(logseq link)](${blockUri})`: ""
+
       let data: {
         content: string;
+        description?: string;
         project_id?: number;
         due_string?: string;
         label_ids?: number[];
       } = {
-        content: appendLogseqUri
-          ? `[${removePrefix(
-              currBlk.content
-            )}](logseq://graph/${currGraphName}?block-id=${currBlk.uuid})`
-          : removePrefix(currBlk.content),
+        content: taskTitle,
+        description: taskDes,
       };
+
       if (sendDefaultProject && sendDefaultProject !== "---")
         data["project_id"] = parseInt(
           getIdFromProjectAndLabel(sendDefaultProject) as string


### PR DESCRIPTION
> I'm not a native English user. Please forgive my grammar errors. Thanks. 🙇 

## Why

Currently, when `appendLogseqUri` is enabled, the whole block will be link to Todoist task. The same behavior happens when  `appendTodoistUrl` is enabled. If there are any links in the block, it will be disabled(like image below).

![image](https://user-images.githubusercontent.com/7992586/173337184-533135f3-b7d6-4f17-acbb-86c428952f91.png)

## What

This PR expands `appendLogseqUri` and `appendTodoistUrl` settings. Let users chose where to append the link in Logseq and Todosit.   

There are three options for links from Logseq to Todoist(`appendTodoistUrl`): `Disable`, `Link content` and `Append link`.  `Disable` and `Link content` act like the original `disable` and `enable`. `Append link` put additional `(todoist)` text at the end of original content and attach the Todoist link on it.

![image](https://user-images.githubusercontent.com/7992586/173340460-ea01c6c5-1ff5-446d-83c0-1f0149a4d7ab.png)

![image](https://user-images.githubusercontent.com/7992586/173341090-78a6d68e-2b64-4c27-abe3-2453d21ef4dd.png)

There are three options for links from Todoist to Logseq as well(`appendLogseqUri`): `Disable`, `Link title` and `Link description`. `Disable` and `Link title` behaviors the same as the old `disable` and `enable`. `Link description` puts Logseq block uri in task description.

![image](https://user-images.githubusercontent.com/7992586/173340450-948eb1e2-b98f-44d5-9ec4-b33cf671fb06.png)

![image](https://user-images.githubusercontent.com/7992586/173341510-7d49178d-f168-44b3-b40b-a6d13250b052.png)


Also, this PR implements the setting migration.



## Note

Even though I think this function are good, I don't think those names of options are good enough to the final product.





