### PR TITLE
Included overdue tasks when querying for today's tasks

### DIFF
--- a/src/services/todoistHelpers.ts
+++ b/src/services/todoistHelpers.ts
@@ -120,7 +120,7 @@ async function retrieveTasksHelper(flag: string) {
   let allTasks: Task[] = [];
 
   if (flag === "today") {
-    allTasks = await api.getTasks({ filter: flag });
+    allTasks = await api.getTasks({ filter: `${flag} | overdue` });
   } else {
     allTasks = await api.getTasks({ projectId: flag });
   }


### PR DESCRIPTION
Hi,
Thanks for the plugin.
Suggesting a small change to retrieving today's tasks via the slash command. I think it is beneficial to include overdue tasks as well as today's tasks so that they can be actioned upon. 