### PR TITLE
Fix the problem of Labels parameter when adding tasks

### DIFF
--- a/src/services/todoistHelpers.ts
+++ b/src/services/todoistHelpers.ts
@@ -235,7 +235,7 @@ export async function syncTask(event: { uuid: string }) {
           (block as BlockEntity).uuid,
           (block as BlockEntity).content,
           getIdFromString(sendDefaultProject),
-          getIdFromString(sendDefaultLabel),
+          getNameFromString(sendDefaultLabel),
           sendDefaultDeadline ? "today" : ""
         );
 


### PR DESCRIPTION
The Todoist API for adding tasks, the labels parameter asks not for an ID but for a Name. The task's labels (a list of names that may represent either personal or shared labels).

So you should use the getNameFromString method.