### PR TITLE
feat: append date/time, task description in child blocks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://editorconfig.org/
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Please let me know what functionalities you would like to add in Logseq's Discor
 
 ## Manual Updating to a new release
 
-After extracting the new zip file, please run `npm run build` again, and reload the plugin in Logseq.
+After extracting the new zip file, please run `yarn run build` again, and reload the plugin in Logseq.
 
 ## Manual Installation
 
@@ -149,7 +149,25 @@ After extracting the new zip file, please run `npm run build` again, and reload 
    - Tasks in Project 298010283 will not be given any prefix after you import, hence you have the flexibility to add them in Todoist.
      ![image](/screenshots/sample-env.png)
 
-7. **RUN THIS STEP ONLY AFTER YOU CREATED THE `.env` file in Step 6** Using the Terminal, go to the root folder (where you can find package.json), and run `npm install && npm run build`. This will install the necessary packages for the plugin. Please ensure that you already have NodeJS installed, if not, [click here to download](https://nodejs.org/en/download/).
+7. **RUN THIS STEP ONLY AFTER YOU CREATED THE `.env` file in Step 6** Using the Terminal, go to the root folder (where you can find package.json), and run `yarn install && yarn run build`. This will install the necessary packages for the plugin. Please ensure that you already have NodeJS installed, if not, [click here to download](https://nodejs.org/en/download/).
 8. Go to Logseq and ensure that you have Developer mode enabled, before going to the Plugins page.
 9. Click "Load unpacked plugin", and navigate to the folder in (2) and click open.
 10. An icon will appear in the usual plugins bar. Navigate to a journal page, and click the button. There may be a delay as the API needs to call your tasks from Todoist. This plugin will not be able to be used on non-journal pages.
+
+# Development
+
+## First run
+
+1. Clone/fork the repo.
+2. Go to the Plugins page on Logseq (`t p`).
+3. Uninstall the plugin.
+4. Run `yarn run build` to build the project.
+5. Click on "Load unpacked plugin" and choose the root directory (the one that contains the `dist` dir just created).
+
+## Changes
+
+1. Change the code.
+2. Run `yarn run build`.
+3. Go to the Plugins page on Logseq (`t p`).
+4. Click on "Reload".
+5. Test your changes.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Simple Todoist plugin to pull only active tasks from specified project, i.e. Inbox",
   "logseq": {
     "id": "logseq-todoist-plugin",
-    "title": "logseq-todoist-plugin",
+    "title": "Todoist",
     "icon": "./icon.png"
   },
   "main": "dist/index.html",

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -78,6 +78,14 @@ export default async function callSettings() {
         "If true, tasks will be added under a parent block with their project name.",
     },
     {
+      key: "retrieveAppendCreationDateTime",
+      type: "boolean",
+      default: false,
+      title: "Append Creation Date and Time",
+      description:
+        "If set to true, all retrieved tasks will have their creation date and time appended.",
+    },
+    {
       key: "retrieveAppendTodo",
       type: "boolean",
       default: true,

--- a/src/services/todoistHelpers.ts
+++ b/src/services/todoistHelpers.ts
@@ -131,13 +131,18 @@ async function retrieveTasksHelper(flag: string) {
     if (!task.parentId) {
       let obj = {
         content: handleContentWithUrlAndTodo(task.content, task),
-        children: [],
+        children: [] as any[],
         properties: {
           todoistid: task.id,
           attachment: "",
           comments: "",
         },
       };
+      if (task.description.length > 0) {
+        for (const line of task.description.split("\n")) {
+          obj.children.push({ content: line });
+        }
+      }
 
       const finalObj = await handleComments(task.id, obj);
 
@@ -160,13 +165,18 @@ async function retrieveTasksHelper(flag: string) {
         if (t.parentId == u.properties.todoistid) {
           let obj = {
             content: handleContentWithUrlAndTodo(t.content, t),
-            children: [],
+            children: [] as any[],
             properties: {
               todoistid: t.id,
               attachment: "",
               comments: "",
             },
           };
+          if (t.description.length > 0) {
+            for (const line of t.description.split("\n")) {
+              obj.children.push({ content: line });
+            }
+          }
 
           const finalObj = await handleComments(t.id, obj);
 

--- a/src/utils/parseStrings.ts
+++ b/src/utils/parseStrings.ts
@@ -1,4 +1,4 @@
-import { getDayInText } from "logseq-dateutils";
+import { getDayInText, getYYMMDDTHHMMFormat } from "logseq-dateutils";
 
 export function getIdFromString(content: string) {
   const regExp = /\((.*?)\)/;
@@ -15,9 +15,27 @@ export function getNameFromString(content: string) {
 }
 
 export function handleContentWithUrlAndTodo(content: string, task: any) {
-  const { retrieveAppendTodo, retrieveAppendUrl } = logseq.settings!;
+  const {
+    retrieveAppendTodo,
+    retrieveAppendUrl,
+    retrieveAppendCreationDateTime,
+  } = logseq.settings!;
+
+  const isoDate = getYYMMDDTHHMMFormat(new Date(task.createdAt));
+  const [datePart, timePart] = isoDate.split("T");
 
   content = retrieveAppendUrl ? `[${content}](${task.url})` : content;
+
+  // Use conventions that conform with the format expected by other plugins:
+  // @ = https://github.com/hkgnp/logseq-datenlp-plugin
+  // **<time>** = https://github.com/QWxleA/logseq-interstitial-heading-plugin
+  // TODO: it would be nice to somehow detect if these plugins are installed,
+  //  then adapt the format to their configs.
+  //  I don't know if some "plugin interop" is possible in Logseq
+  content = retrieveAppendCreationDateTime
+    ? `@${datePart} **${timePart}** ${content}`
+    : content;
+
   content = retrieveAppendTodo ? `TODO ${content}` : content;
   content = task.due
     ? `${content}


### PR DESCRIPTION
Thank you for this project!

I added some small features I'm using:

1. New boolean setting to add the creation date/time of the task before the content (default: false).
2. Add the task's description as child blocks.

And some internal improvements:

1. [.editorconfig](https://editorconfig.org/)
2. Replace `npm` references by `yarn`, since [the repo has a yarn.lock file](https://github.com/hkgnp/logseq-todoist-plugin/blob/master/yarn.lock).
3. A small "Development" section on the README.
4. Rename the project title to "Todoist" because it looks better on the settings page. 😬😄
![image](https://github.com/hkgnp/logseq-todoist-plugin/assets/1258218/4931fdc4-abd6-4a97-9e5a-9d8382d50c19)

Let me know what you think. 🙂 